### PR TITLE
work-headerをパーシャルに切り出した

### DIFF
--- a/app/views/works/_work-header.html.slim
+++ b/app/views/works/_work-header.html.slim
@@ -1,0 +1,12 @@
+- if @work
+  .work-header
+    .work-header__title
+      = @work.title
+      .work-header__title-item
+        = link_to edit_work_path(@work)
+          i.fas.fa-cog
+    .work-header__deadline
+      | 締切まであと
+      span
+        = (@work.deadline - Date.today).numerator
+      | 日

--- a/app/views/works/edit.html.slim
+++ b/app/views/works/edit.html.slim
@@ -1,15 +1,5 @@
 .page-body
-  .work-header
-    .work-header__title
-      = @work.title
-      .work-header__title-item
-        = link_to edit_work_path(@work)
-          i.fas.fa-cog
-    .work-header__deadline
-      | 締め切りまであと
-      span
-        = (@work.deadline - Date.today).numerator
-      | 日
+  = render "work-header"
   .container
     .form-container
       .form-title

--- a/app/views/works/index.html.slim
+++ b/app/views/works/index.html.slim
@@ -1,4 +1,3 @@
-
 .page-body
   .container
     .works-table

--- a/app/views/works/show.html.slim
+++ b/app/views/works/show.html.slim
@@ -1,15 +1,5 @@
 .page-body
-  .work-header
-    .work-header__title
-      = @work.title
-      .work-header__title-item
-        = link_to edit_work_path(@work)
-          i.fas.fa-cog
-    .work-header__deadline
-      | 締め切りまであと
-      span
-        = (@work.deadline - Date.today).numerator
-      | 日
+  = render "work-header"
   .container
     .card
       .card-tabs

--- a/app/views/works/stages/edit.html.slim
+++ b/app/views/works/stages/edit.html.slim
@@ -1,15 +1,5 @@
 .page-body
-  .work-header
-    .work-header__title
-      = @work.title
-      .work-header__title-item
-        = link_to edit_work_path(@work)
-          i.fas.fa-cog
-    .work-header__deadline
-      | 締め切りまであと
-      span
-        = (@work.deadline - Date.today).numerator
-      | 日
+  = render "works/work-header"
   .container
     .form-container
       .form-title

--- a/app/views/works/stages/index.html.slim
+++ b/app/views/works/stages/index.html.slim
@@ -1,15 +1,5 @@
 .page-body
-  .work-header
-    .work-header__title
-      = @work.title
-      .work-header__title-item
-        = link_to edit_work_path(@work)
-          i.fas.fa-cog
-    .work-header__deadline
-      | 締め切りまであと
-      span
-        = (@work.deadline - Date.today).numerator
-      | 日
+  = render "works/work-header"
   .container
     .stages-table
       .stages-table__head

--- a/app/views/works/stages/new.html.slim
+++ b/app/views/works/stages/new.html.slim
@@ -1,15 +1,5 @@
 .page-body
-  .work-header
-    .work-header__title
-      = @work.title
-      .work-header__title-item
-        = link_to edit_work_path(@work)
-          i.fas.fa-cog
-    .work-header__deadline
-      | 締め切りまであと
-      span
-        = (@work.deadline - Date.today).numerator
-      | 日
+  = render "works/work-header"
   .container
     .form-container
       .form-title

--- a/app/views/works/stages/show.html.slim
+++ b/app/views/works/stages/show.html.slim
@@ -1,15 +1,5 @@
 .page-body
-  .work-header
-    .work-header__title
-      = @work.title
-      .work-header__title-item
-        = link_to edit_work_path(@work)
-          i.fas.fa-cog
-    .work-header__deadline
-      | 締め切りまであと
-      span
-        = (@work.deadline - Date.today).numerator
-      | 日
+  = render "works/work-header"
   .container
     .card
       .card-tabs


### PR DESCRIPTION
- 手順の保存に失敗した時に、work-headerでエラーが出てしまうため
- パーシャルにまとめ、workが空の時はヘッダーを表示しない